### PR TITLE
docs: 补充 statusline 自定义状态栏和 API Key 功能限制说明

### DIFF
--- a/docs/claude-code/02-基础使用完整指南.md
+++ b/docs/claude-code/02-基础使用完整指南.md
@@ -1371,6 +1371,74 @@ You: /config
 
 ---
 
+#### /statusline - 自定义状态栏
+
+**作用**：用自然语言描述你想在终端底部状态栏显示的信息，Claude 自动生成脚本并配置
+
+**一句话理解**：终端底部的"仪表盘"——模型、上下文用量、费用、Git 分支，一目了然。
+
+**使用方式**：
+
+```bash
+# 用自然语言描述你想看到的内容
+You: /statusline 显示模型名(青色+🤖)、上下文使用百分比(◉图标，绿/黄/红三色阈值50%/80%)、已用/总量(📊图标，总量暗色)、总token数(⚡紫色)，用 │
+  分隔。注意Windows兼容，用node流式读stdin不要用/dev/stdin
+
+# 更复杂的定制
+You: /statusline show model name, context percentage with a progress bar, cost, and duration
+
+# 删除/禁用状态栏
+You: /statusline delete
+```
+
+**手动配置**：
+
+在 `~/.claude/settings.json` 中直接配置：
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh",
+    "refreshInterval": 5,
+    "hideVimModeIndicator": true
+  }
+}
+```
+
+| 配置项 | 类型 | 说明 |
+|--------|------|------|
+| `type` | string | 固定为 `"command"` |
+| `command` | string | 脚本路径或内联 shell 命令 |
+| `refreshInterval` | number | 每 N 秒刷新一次（最小 1） |
+| `hideVimModeIndicator` | boolean | 隐藏内置的 Vim 模式指示 |
+
+**状态栏脚本可用的数据**（通过 stdin 接收 JSON）：
+
+| 字段 | 说明 |
+|------|------|
+| `model.display_name` | 当前模型名 |
+| `context_window.used_percentage` | 上下文使用百分比 |
+| `context_window.context_window_size` | 上下文窗口大小（200K/1M） |
+| `cost.total_cost_usd` | 本次会话预估费用 |
+| `cost.total_duration_ms` | 会话持续时间 |
+| `workspace.current_dir` | 当前工作目录 |
+| `workspace.repo` | Git 仓库信息（host, owner, name） |
+| `rate_limits.five_hour.used_percentage` | 5小时限额使用比（订阅用户） |
+| `effort.level` | 当前推理深度级别 |
+| `vim.mode` | 当前 Vim 模式 |
+
+**简单示例脚本**（`~/.claude/statusline.sh`）：
+
+```bash
+#!/bin/bash
+jq -r '"\(.model.display_name) | ctx: \(.context_window.used_percentage // 0)% | $\(.cost.total_cost_usd // 0 | tostring[:5])"'
+```
+
+> 💡 **提示**：脚本支持 ANSI 颜色码、多行输出（每行一个 echo）、OSC 8 超链接。终端宽度通过 `$COLUMNS` 获取。
+
+---
+
 #### /release-notes - 查看更新日志
 
 **作用**：查看各版本更新说明。
@@ -2048,6 +2116,35 @@ npm update -g @anthropic-ai/claude-code
 | .mcp.json | 项目根目录 | MCP服务器配置 |
 | ~/.claude/ | 用户目录 | 全局配置 |
 | ~/.claude/commands/ | 用户目录 | 个人 legacy Slash 命令 |
+
+---
+
+## 附录：API Key 用户功能限制说明
+
+> ⚠️ **重要**：以下功能**仅限订阅用户**（Pro/Max/Team/Enterprise 通过 `claude.ai` OAuth 登录），使用 `ANTHROPIC_API_KEY` 或第三方云（Bedrock/Vertex/Foundry）时**不可用**。
+
+| 功能 / 命令 | 说明 | API Key | 订阅登录 |
+|-------------|------|:-------:|:--------:|
+| `/voice` | 语音输入模式 | ❌ | ✅ |
+| `/remote-control` | 从 claude.ai / 手机 App 接管本地会话 | ❌ | ✅ |
+| `/fast` | 快速输出模式 | ❌ | ✅ |
+| `/ultraplan` | 在 Web 端起草 Plan 并回传 | ❌ | ✅ |
+| Auto mode | 权限模式中的"自动判断"选项 | ❌ | ✅ |
+| Claude Code on the Web | `claude.ai/code` 网页版 | ❌ | ✅ |
+| Routines / `/schedule` | 云端定时调度执行 | ❌ | ✅ |
+| Rate limit 数据 | 状态栏中的 5h/7d 限额百分比 | ❌ | ✅ |
+
+**如何判断你的认证方式**：
+
+```bash
+# 如果你是通过环境变量设置的 key，就是 API Key 模式
+echo $ANTHROPIC_API_KEY
+
+# 如果你是通过以下方式登录的，就是订阅模式
+claude login
+```
+
+> 💡 **建议**：如果你主要使用 API Key 且需要语音功能，可以考虑升级到 Pro 订阅；如果只是偶尔用，核心的代码编辑、文件操作、MCP 集成等功能在 API Key 模式下完全可用。
 
 ---
 


### PR DESCRIPTION
## Summary

- 在 `02-基础使用完整指南.md` 第 4.9 节新增 `/statusline` 自定义状态栏功能介绍，包含自然语言用法、`settings.json` 配置方式、可用数据字段和示例脚本
- 新增"附录：API Key 用户功能限制说明"，明确列出 `/voice`、`/remote-control`、`/fast`、`/ultraplan` 等仅订阅登录可用的功能对比表

## Test plan

- [ ] 确认 Markdown 格式渲染正常（表格、代码块、引用）
- [ ] 确认新增内容与文件中已有风格一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)